### PR TITLE
Improvement: Dockerfile for use with Omnibus GitLab Docker instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:2.7.11
+
+MAINTAINER "Matt Martz <matt.martz@gmail.com>"
+
+COPY . /src
+
+RUN cd /src; pip install -r requirements.txt
+
+EXPOSE 5000
+
+ENTRYPOINT cd /src; python server.py

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This is primarily for use with a Docker instance of Gitlab (Mattermost may or ma
     - Add `--link mattermost-integration-gitlab:mattermost-integration-gitlab`
 
 3. **Connect your project to your GitLab account for outgoing webhooks**
- 1. Log in to GitLab account and open the project from which you want to receive updates and to which you have administrator access. From the left side of the project screen, click on **Settings** > **Web Hooks**. In the **URL** field enter `http://mattermost-integration-gitlab/new_event`
+ 1. Log in to GitLab account and open the project from which you want to receive updates and to which you have administrator access. From the left side of the project screen, click on **Settings** > **Web Hooks**. In the **URL** field enter `http://mattermost-integration-gitlab:5000/new_event`
  2. On the same page, under **Trigger** select **Push events**, **Comment events**, **Issue events**, **Merge Request events**
  3. Uncheck **Enable SSL verification**.  SSL Verification is not necessary since the containers are linked and mattermost-integration-gitlab container is not publishing the port.
  4. Click **Add Web Hook** and check that your new webhook entry is added to the **Web hooks** section below the button.
@@ -143,3 +143,16 @@ This is primarily for use with a Docker instance of Gitlab (Mattermost may or ma
       - `docker run -e "MATTERMOST_WEBHOOK_URL=https://<your-mattermost-webhook-URL>" --name mattermost-integration-gitlab -e "SSL_VERIFY=False" -d mattermost-integration-gitlab`
       - Remove and re-run your gitlab container (not sure if this is avoidable, only way I could get it to work)
   4. If you have any issues, please go to http://forum.mattermost.org and let us know which steps in these instructions were unclear or didn't work.
+
+### Channel Specific Webhooks
+Say you have an issues channel and you want your issues to go there, and your merge requests to a different channel... (Note: you still need a default channel setup via `MATTERMOST_WEBHOOK_URL`
+
+1. **Set up your Mattermost instance to receive incoming webhooks**
+ 1. Log in to your Mattermost account. Click the three dot menu at the top of the left-hand side and go to **Account Settings** > **Integrations** > **Incoming Webhooks**.
+ 2. Under **Add a new incoming webhook** select the channel in which you want GitLab notifications to appear, then click **Add** to create a new entry.
+ 3. Copy the contents next to **URL** of the new webhook you just created (we'll refer to this as `https://<your-mattermost>/hooks/<channel_hook_code>`).
+2. Add the webhook to the GitLab configuration you want
+ 1. Log in to GitLab account and open the project from which you want to receive updates and to which you have administrator access. From the left side of the project screen, click on **Settings** > **Web Hooks**. In the **URL** field enter `http://mattermost-integration-gitlab:5000/new_event_hook/<channel_hook_code>`
+ 2. On the same page, under **Trigger** select what you want to go to that channel... **Push events**, **Comment events**, **Issue events**, **Merge Request events**
+ 3. Uncheck **Enable SSL verification**.  SSL Verification is not necessary since the containers are linked and mattermost-integration-gitlab container is not publishing the port.
+ 4. Click **Add Web Hook** and check that your new webhook entry is added to the **Web hooks** section below the button.

--- a/server.py
+++ b/server.py
@@ -8,8 +8,6 @@ from flask import request
 
 app = Flask(__name__)
 
-app.debug = True
-
 USERNAME = 'gitlab'
 ICON_URL = 'https://gitlab.com/uploads/project/avatar/13083/gitlab-logo-square.png'
 MATTERMOST_WEBHOOK_URL = '' # Paste the Mattermost webhook URL you created here

--- a/server.py
+++ b/server.py
@@ -8,10 +8,13 @@ from flask import request
 
 app = Flask(__name__)
 
+app.debug = True
+
 USERNAME = 'gitlab'
 ICON_URL = 'https://gitlab.com/uploads/project/avatar/13083/gitlab-logo-square.png'
 MATTERMOST_WEBHOOK_URL = '' # Paste the Mattermost webhook URL you created here
 CHANNEL = '' # Leave this blank to post to the default channel of your webhook
+SSL_VERIFY = True
 
 PUSH_EVENT = 'push'
 ISSUE_EVENT = 'issue'
@@ -193,7 +196,10 @@ def post_text(text):
         data['channel'] = CHANNEL
 
     headers = {'Content-Type': 'application/json'}
-    r = requests.post(MATTERMOST_WEBHOOK_URL, headers=headers, data=json.dumps(data))
+    if SSL_VERIFY:
+        r = requests.post(MATTERMOST_WEBHOOK_URL, headers=headers, data=json.dumps(data))
+    else:
+        r = requests.post(MATTERMOST_WEBHOOK_URL, headers=headers, data=json.dumps(data), verify=False)
 
     if r.status_code is not requests.codes.ok:
         print 'Encountered error posting to Mattermost URL %s, status=%d, response_body=%s' % (MATTERMOST_WEBHOOK_URL, r.status_code, r.json())
@@ -231,6 +237,7 @@ if __name__ == "__main__":
     CHANNEL = os.environ.get('CHANNEL', CHANNEL)
     USERNAME = os.environ.get('USERNAME', USERNAME)
     ICON_URL = os.environ.get('ICON_URL', ICON_URL)
+    SSL_VERIFY = os.environ.get('SSL_VERIFY', 'True') == 'True'
 
     REPORT_EVENTS[PUSH_EVENT] = os.environ.get('PUSH_TRIGGER', str(REPORT_EVENTS[PUSH_EVENT])) == 'True'
     REPORT_EVENTS[ISSUE_EVENT] = os.environ.get('ISSUE_TRIGGER', str(REPORT_EVENTS[ISSUE_EVENT])) == 'True'

--- a/server.py
+++ b/server.py
@@ -48,125 +48,8 @@ def new_event():
 
     data = request.json
     object_kind = data['object_kind']
-
-    text = ''
-    base_url = ''
-
-    if REPORT_EVENTS[PUSH_EVENT] and  object_kind == PUSH_EVENT:
-        text = '%s pushed %d commit(s) into the `%s` branch for project [%s](%s).' % (
-            data['user_name'],
-            data['total_commits_count'],
-            data['ref'],
-            data['repository']['name'],
-            data['repository']['homepage']
-        )
-    elif REPORT_EVENTS[ISSUE_EVENT] and object_kind == ISSUE_EVENT:
-        action = data['object_attributes']['action']
-
-        if action == 'open' or action == 'reopen':
-            description = add_markdown_quotes(data['object_attributes']['description'])
-
-            text = '#### [%s](%s)\n*[Issue #%s](%s/issues) created by %s in [%s](%s) on [%s](%s)*\n %s' % (
-                data['object_attributes']['title'],
-                data['object_attributes']['url'],
-                data['object_attributes']['iid'],
-                data['repository']['homepage'],
-                data['user']['username'],
-                data['repository']['name'],
-                data['repository']['homepage'],
-                data['object_attributes']['created_at'],
-                data['object_attributes']['url'],
-                description
-            )
-
-            base_url = data['repository']['homepage']
-    elif REPORT_EVENTS[TAG_EVENT] and object_kind == TAG_EVENT:
-        text = '%s pushed tag `%s` to the project [%s](%s).' % (
-            data['user_name'],
-            data['ref'],
-            data['repository']['name'],
-            data['repository']['homepage']
-        )
-    elif REPORT_EVENTS[COMMENT_EVENT] and object_kind == COMMENT_EVENT:
-        symbol = ''
-        type_grammar = 'a'
-        note_type = data['object_attributes']['noteable_type'].lower()
-        note_id = ''
-        parent_title = ''
-
-        if note_type == 'mergerequest':
-            symbol = '!'
-            note_id = data['merge_request']['iid']
-            parent_title = data['merge_request']['title']
-            note_type = 'merge request'
-        elif note_type == 'snippet':
-            symbol = '$'
-            note_id = data['snippet']['iid']
-            parent_title = data['snippet']['title']
-        elif note_type == 'issue':
-            symbol = '#'
-            note_id = data['issue']['iid']
-            parent_title = data['issue']['title']
-            type_grammar = 'an'
-
-        subtitle = ''
-        if note_type == 'commit':
-            subtitle = '%s' % data['commit']['id']
-        else:
-            subtitle = '%s%s - %s' % (symbol, note_id, parent_title)
-
-        description = add_markdown_quotes(data['object_attributes']['note'])
-
-        text = '#### **New Comment** on [%s](%s)\n*[%s](https://gitlab.com/u/%s) commented on %s %s in [%s](%s) on [%s](%s)*\n %s' % (
-            subtitle,
-            data['object_attributes']['url'],
-            data['user']['username'],
-            data['user']['username'],
-            type_grammar,
-            note_type,
-            data['repository']['name'],
-            data['repository']['homepage'],
-            data['object_attributes']['created_at'],
-            data['object_attributes']['url'],
-            description
-        )
-
-        base_url = data['repository']['homepage']
-    elif REPORT_EVENTS[MERGE_EVENT] and object_kind == MERGE_EVENT:
-        action = data['object_attributes']['action']
-
-        if action == 'open':
-            text_action = 'created a'
-        elif action == 'reopen':
-            text_action = 'reopened a'
-        elif action == 'update':
-            text_action = 'updated a'
-        elif action == 'merge':
-            text_action = 'accepted a'
-        elif action == 'close':
-            text_action = 'closed a'
-
-        text = '#### [!%s - %s](%s)\n*[%s](https://gitlab.com/u/%s) %s merge request in [%s](%s) on [%s](%s)*' % (
-            data['object_attributes']['iid'],
-            data['object_attributes']['title'],
-            data['object_attributes']['url'],
-            data['user']['username'],
-            data['user']['username'],
-            text_action,
-            data['object_attributes']['target']['name'],
-            data['object_attributes']['target']['web_url'],
-            data['object_attributes']['created_at'],
-            data['object_attributes']['url']
-        )
-
-        if action == 'open':
-            description = add_markdown_quotes(data['object_attributes']['description'])
-            text = '%s\n %s' % (
-                text,
-                description
-            )
-
-        base_url = data['object_attributes']['target']['web_url']
+    
+    text, base_url = process_data(data, object_kind)
 
     if len(text) == 0:
         print 'Text was empty so nothing sent to Mattermost, object_kind=%s' % object_kind
@@ -192,6 +75,22 @@ def new_event_hook(use_this_hook):
     data = request.json
     object_kind = data['object_kind']
 
+    text, base_url = process_data(data, object_kind)
+
+    if len(text) == 0:
+        print 'Text was empty so nothing sent to Mattermost, object_kind=%s' % object_kind
+        return 'OK'
+
+    if len(base_url) != 0:
+        text = fix_gitlab_links(base_url, text)
+
+    url_to_use = MATTERMOST_WEBHOOK_URL[0:MATTERMOST_WEBHOOK_URL.find("/hooks/")+7] + use_this_hook
+
+    post_text(text, url_to_use)
+
+    return 'OK'
+
+def process_data(data, object_kind):
     text = ''
     base_url = ''
 
@@ -310,19 +209,8 @@ def new_event_hook(use_this_hook):
             )
 
         base_url = data['object_attributes']['target']['web_url']
-
-    if len(text) == 0:
-        print 'Text was empty so nothing sent to Mattermost, object_kind=%s' % object_kind
-        return 'OK'
-
-    if len(base_url) != 0:
-        text = fix_gitlab_links(base_url, text)
-
-    url_to_use = MATTERMOST_WEBHOOK_URL[0:MATTERMOST_WEBHOOK_URL.find("/hooks/")+7] + use_this_hook
-
-    post_text(text, url_to_use)
-
-    return 'OK'
+        
+    return (text, base_url)
 
 def post_text(text, url_to_use):
     """


### PR DESCRIPTION
Personally I run my GitLab + Mattermost using a Docker container.  I wanted to integrate the two but it doesn't seem to be built in (...yet?), so I made a Dockerfile for this project and now run these in two containers linked together.

I also added something to disable SSL Verification (which may be useful to some people if they use self-signed certificates).  It defaults to `true`
